### PR TITLE
Add a dedicated trilinear solver to solver.py

### DIFF
--- a/CFM_main/solver.py
+++ b/CFM_main/solver.py
@@ -11,6 +11,7 @@ from scipy.sparse import spdiags
 import scipy.sparse.linalg as splin
 from constants import *
 import sys
+from scipy.linalg import lapack
 
 
 def solver(a_U, a_D, a_P, b):
@@ -25,17 +26,38 @@ def solver(a_U, a_D, a_P, b):
     :return phi_t:
     '''
 
-    nz = np.size(b)
+    #NOTE: lapack contains a dedicated solver that handles tridagonal
+    # solutions.  It's quite a bit faster than using the general spsolve
+    # function.  I've included two boolean variables that let you choose
+    # which function to solve the equation-- if both are enabled, the
+    # normalized difference between the results will be reported.
 
-    diags = (np.append([a_U, -a_P], [a_D], axis = 0))
-    cols = np.array([1, 0, -1])
+    #use_splin=True
+    #use_dgtsv=False
 
-    big_A = spdiags(diags, cols, nz, nz, format = 'csc')
-    big_A = big_A.T
+    use_splin=False
+    use_dgtsv=True
+    if use_splin:
+        nz = np.size(b)
 
-    rhs = -b
-    phi_t = splin.spsolve(big_A, rhs)
+        diags = (np.append([a_U, -a_P], [a_D], axis = 0))
+        cols = np.array([1, 0, -1])
 
+        big_A = spdiags(diags, cols, nz, nz, format = 'csc')
+        big_A = big_A.T
+
+        rhs = -b
+        phi_t = splin.spsolve(big_A, rhs)
+        if use_dgtsv:
+            phi_t_spsolve=phi_t.copy()
+    if use_dgtsv:
+        dl=np.ascontiguousarray(a_U[1:])
+        d=np.ascontiguousarray(-a_P)
+        du=np.ascontiguousarray(a_D[:-1])
+        rhs = np.ascontiguousarray(-b)
+        _, _, _, phi_t, _ = lapack.dgtsv(dl, d, du, rhs)
+    if use_splin and use_dgtsv:
+        print(np.max(np.abs(phi_t-phi_t_spsolve))/np.median(np.abs(phi_t)))
     return phi_t
 
 ####!!!!
@@ -63,12 +85,12 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
     phi_t_old = phi_t.copy()
 
     for i_time in range(nt):
-    
+
         dZ = np.diff(z_edges) #width of nodes
 
         deltaZ_u = np.diff(Z_P)
         deltaZ_u = np.append(deltaZ_u[0], deltaZ_u)
-        
+
         deltaZ_d = np.diff(Z_P)
         deltaZ_d = np.append(deltaZ_d, deltaZ_d[-1])
 
@@ -77,7 +99,7 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 
         #######################################
         # this part is for gas diffusion, which takes a bit more physics
-        if airdict!=None: 
+        if airdict!=None:
             Gamma_Po    = Gamma_P * airdict['por_op'] #This is the diffusivity times the open porosity.
 
             Gamma_U     = np.append(Gamma_Po[0], Gamma_Po[0: -1] )
@@ -90,7 +112,7 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
             d_eddy_D    = np.append(d_eddy_P[1:], d_eddy_P[-1])
             d_eddy_u    =  1/ ( (1 - f_u)/d_eddy_P + f_u/d_eddy_U )
             d_eddy_d    =  1/ ( (1 - f_d)/d_eddy_P + f_d/d_eddy_D )
-            
+
             if airdict['gravity']=="off" and airdict['thermal']=="off":
                 S_C_0   = 0.0
 
@@ -107,16 +129,16 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
             else:
                 print('Error at in solver.py at 119')
                 sys.exit()
-            
+
             S_C         = S_C_0 * phi_t
-            b_0         = S_C * dZ 
+            b_0         = S_C * dZ
 
             rho_edges = np.interp(z_edges,Z_P,airdict['rho'])
-            
+
             w_edges = w(airdict, z_edges, rho_edges, Z_P, dZ) # advection term (upward relative motion due to porosity changing)
 
             w_p = np.interp(Z_P,z_edges,w_edges) # Units m/s
-            w_edges[z_edges>airdict['z_co']] = 0.0          
+            w_edges[z_edges>airdict['z_co']] = 0.0
             w_u = w_edges[0:-1]
             w_d = w_edges[1:]
 
@@ -125,24 +147,24 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 
             F_u =  w_u * airdict['por_op'] # Units m/s
             F_d =  w_d * airdict['por_op']
-            
+
             P_u = F_u / D_u
             P_d = F_d / D_d
 
             op_ind              = np.where(z_edges<=airdict['z_co'])[0] #indices of all nodes wiht open porosity (shallower than CO)
             op_ind2             = np.where(z_edges<=airdict['z_co']+20)[0] # a bit deeper
             co_ind              = op_ind[-1]
-            
+
             a_U = D_u * A( P_u ) + F_upwind(  F_u )
             a_D = D_d * A( P_d ) + F_upwind( -F_d )
-        
+
             a_P_0 = airdict['por_op'] * dZ / dt
         #######################################
         ### end gas physics portion ###########
         #######################################
 
-        #######################################        
-        else: # just for heat, enthalpy, isotope diffusion 
+        #######################################
+        else: # just for heat, enthalpy, isotope diffusion
             Gamma_U = np.append(Gamma_P[0], Gamma_P[0: -1] )
             Gamma_D = np.append(Gamma_P[1:], Gamma_P[-1])
 
@@ -200,7 +222,7 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
             b[-1]   = deltaZ_u[-1] * bc_d[0]
         elif bc_type_d==1:
             a_U[-1] = 0
-            b[-1]   = bc_d[0]            
+            b[-1]   = bc_d[0]
 
         phi_t = solver(a_U, a_D, a_P, b)
 
@@ -218,7 +240,7 @@ def transient_solve_TR(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s, mix_rho, c_vol, LWC, mass_sol, dz, ICT, rho_firn, iii=0):
     '''
     transient 1-d diffusion finite volume method for enthalpy
-    
+
     This is for heat diffusion when there is liquid water present.
     It uses a source term for the latent heat associated with the liquid water.
 
@@ -254,11 +276,11 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
     g_sol       = vol_S / dz #unitless
 
     dZ = np.diff(z_edges) #width of nodes
-      
+
     H_L_liq = RHO_W_KGM*LF_I #volumetric latent enthalpy [J/m3]
-    
+
     phi_t = phi_0 # phi_t is just the temperature
-    
+
     phi_t_old = phi_t.copy() # initial temperature
     g_liq_old = g_liq.copy() # initial liquid fraction
     g_sol_old = g_sol.copy() # initial solid fraction
@@ -290,7 +312,7 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 
         deltaZ_u = np.diff(Z_P) # [m]
         deltaZ_u = np.append(deltaZ_u[0], deltaZ_u)
-        
+
         deltaZ_d = np.diff(Z_P)
         deltaZ_d = np.append(deltaZ_d, deltaZ_d[-1])
 
@@ -312,22 +334,22 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 
         D_u = (Gamma_u / deltaZ_u) # [W/m2/K]
         D_d = (Gamma_d / deltaZ_d)
-        
+
         a_U   = D_u        #* dt # [W/m2/K]
         a_D   = D_d        #* dt # [W/m2/K]
-        
-        c_vol1 = RHO_I * CP_I # gets multiplied by g_sol below 
-        
-        a_P_0 = c_vol1 * dZ / dt # [W/m2/K] (new) Patankar eq. 4.41c, this is b_p in Voller (1990; Eq. 30)         
+
+        c_vol1 = RHO_I * CP_I # gets multiplied by g_sol below
+
+        a_P_0 = c_vol1 * dZ / dt # [W/m2/K] (new) Patankar eq. 4.41c, this is b_p in Voller (1990; Eq. 30)
 
         if update_gsol:
             a_P   = a_U + a_D + a_P_0 * g_sol_iter - S_P * dZ #* dt # check the multiply on the S_P
         else:
             a_P   = a_U + a_D + a_P_0 * g_sol_old - S_P * dZ #* dt # check the multiply on the S_P
-            
+
         b_0   = S_C * dZ/dt #* dt # [W/m2]
         b     = b_0 + a_P_0 * g_sol_old * phi_t_old # By this phi_t_old has to be in K
-        
+
         ###############
 
         ### Boundary conditions:
@@ -357,18 +379,18 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
             b[-1]   = deltaZ_u[-1] * bc_d[0]
         elif bc_type_d==1: # Fixed value
             a_U[-1] = 0
-            b[-1]   = bc_d[0]   
+            b[-1]   = bc_d[0]
 
         #####
         phi_t = solver(a_U, a_D, a_P, b) #sensible enthalpy. 0 for layers at freezing (have LWC), negative for dry layers
         #####
 
-        ''' 
+        '''
         ####
         The crux is to adjust liquid fraction and temperture field based on solution
         Calculations are (partially) based on the fact that the freezing temp is 0,
         which means that if H_tot<0 there is no liquid and you can calculate temperature, and if H_tot>0 there is liquid and T is 0.
-        
+
         Note previous ways of solving in dev branch and previous releases.
         ###
         '''
@@ -378,7 +400,7 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 
         h_updated = phi_t * CP_I * RHO_I * g_sol_old # updated sensible enthalpy after solver. g_sol is volume_solid/dz
         delta_h = h_updated - h_old # change in sensible enthalpy, relative to initial (not iteration)
-        
+
         ### Figure out what delta_h and g_liq should be based on different conditions
         cond0 = ((delta_h>0) & (LWC_old>0)) # Layers where there was sensible enthalpy increased and there is liquid water
         delta_h[cond0] = 0 # sensible enthalpy should not increase if LWC present (should either stay at 0C or cool down)
@@ -419,7 +441,7 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
         ## Now update temperatures after liquid corrections
         phi_t[H_tot>=0] = 0 # H_tot>0 means liquid present, T=0
         phi_t[H_tot<0] = H_tot[H_tot<0] / (CP_I * RHO_I * g_sol_old[H_tot<0]) # H_tot<0 means no liquid; all enthalpy is sensible
-        
+
         phi_t[g_liq>0] = 0
         #############
 
@@ -427,10 +449,10 @@ def transient_solve_EN(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s,
 
         ### END ITERATION LOOP
         ######################
-    
+
     phi_t_out = phi_t
     phi_t_out[g_liq>0] = 0
-    phi_t_out[(phi_t_out>0)] = 0 
+    phi_t_out[(phi_t_out>0)] = 0
 
     return phi_t_out, g_liq, count, iterdiff,g_sol
 
@@ -470,12 +492,12 @@ def apparent_heat(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s, mix_
     g_sol       = vol_S / dz #unitless
 
     dZ = np.diff(z_edges) #width of nodes
-      
+
     H_L_liq = RHO_W_KGM*LF_I #volumetric latent enthalpy [J/m3]
-    
+
     phi_t = phi_0 # phi_t is just the temperature, C
     phi_t_old = phi_t.copy()
-    
+
     phi_t_old = phi_t.copy() # initial temperature
     g_liq_old = g_liq.copy() # initial liquid fraction
     g_sol_old = g_sol.copy() # initial solid fraction
@@ -500,12 +522,12 @@ def apparent_heat(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s, mix_
 
         # C_app = (delH**2/delT**2)**0.5
         # if i_time == 0:
-        
+
         # C_app = np.zeros_like(phi_t)
         C_app_0 = g_liq_iter * H_L_liq * 50
 
         c_vol = c_vol + C_app_0
-        
+
         # else:
         #     C_app = (H_tot - H_tot_old)/(phi_t_iter - phi_t_old)
 
@@ -516,14 +538,14 @@ def apparent_heat(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s, mix_
 
         deltaZ_u = np.diff(Z_P)
         deltaZ_u = np.append(deltaZ_u[0], deltaZ_u)
-        
+
         deltaZ_d = np.diff(Z_P)
         deltaZ_d = np.append(deltaZ_d, deltaZ_d[-1])
 
         f_u = 1 - (Z_P[:] - z_edges[0:-1]) / deltaZ_u[:]
         f_d = 1 - (z_edges[1:] - Z_P[:]) / deltaZ_d[:]
 
-        #######################################        
+        #######################################
         Gamma_U = np.append(Gamma_P[0], Gamma_P[0: -1] )
         Gamma_D = np.append(Gamma_P[1:], Gamma_P[-1])
 
@@ -581,7 +603,7 @@ def apparent_heat(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s, mix_
             b[-1]   = deltaZ_u[-1] * bc_d[0]
         elif bc_type_d==1:
             a_U[-1] = 0
-            b[-1]   = bc_d[0]            
+            b[-1]   = bc_d[0]
 
         phi_t = solver(a_U, a_D, a_P, b)
 
@@ -643,9 +665,9 @@ def apparent_heat(z_edges, Z_P, nt, dt, Gamma_P, phi_0, nz_P, nz_fv, phi_s, mix_
 Functions below are for firn air
 Works, but consider to be in beta
 '''
-def w(airdict, z_edges, rho_edges, Z_P, dZ): 
+def w(airdict, z_edges, rho_edges, Z_P, dZ):
     '''
-    Function for downward advection of air and also calculates total air content. 
+    Function for downward advection of air and also calculates total air content.
     '''
     if airdict['advection_type']=='Darcy':
         por_op_edges=np.interp(z_edges,airdict['z'],airdict['por_op'])
@@ -655,8 +677,8 @@ def w(airdict, z_edges, rho_edges, Z_P, dZ):
         dPdz_edges=np.interp(z_edges,airdict['z'],dPdz)
 
         # perm = 10.0**(-7.29) * por_op_edges**3.71 # Adolph and Albert, 2014, eq. 5, units m^2
-        # perm = 10.0**(-7.7) * por_op_edges**3.4 #Freitag, 2002 
-        perm = 10.0**(-7.7) * p_star**3.4 #Freitag, 2002 
+        # perm = 10.0**(-7.7) * por_op_edges**3.4 #Freitag, 2002
+        perm = 10.0**(-7.7) * p_star**3.4 #Freitag, 2002
         visc = 1.5e-5 #kg m^-1 s^-1, dynamic viscosity, source?
         flux = -1.0 * perm / visc * dPdz_edges # units m/s
         # w_ad = flux / airdict['dt']  / por_op_edges # where did I get this?
@@ -675,7 +697,7 @@ def w(airdict, z_edges, rho_edges, Z_P, dZ):
 
         op_ind              = np.where(z_edges<=airdict['z_co'])[0] #indices of all nodes wiht open porosity (shallower than CO)
         op_ind2             = np.where(z_edges<=airdict['z_co']+20)[0] # a bit deeper
-        co_ind              = op_ind[-1] 
+        co_ind              = op_ind[-1]
         cl_ind1             = np.where(z_edges>airdict['z_co'])[0] #closed indices
         cl_ind              = np.intersect1d(cl_ind1,op_ind2)
 
@@ -686,7 +708,7 @@ def w(airdict, z_edges, rho_edges, Z_P, dZ):
         Xi_down             = (1 + np.log( np.reshape(w_firn_edges[op_ind2], (-1,1))/ w_firn_edges[op_ind2] ))
         Xi                  = Xi_up / Xi_down # Equation 5.10 in Christo's thesis; Xi[i,j] is the pressure increase (ratio) for bubbles at depth[i] that were trapped at depth[j]
 
-        integral_matrix     = (Xi.T*dscl[op_ind2]*C[op_ind2]).T 
+        integral_matrix     = (Xi.T*dscl[op_ind2]*C[op_ind2]).T
         integral_matrix_sum = integral_matrix.sum(axis=1)
 
         p_ratio_t           = np.zeros_like(op_ind2)
@@ -704,7 +726,7 @@ def w(airdict, z_edges, rho_edges, Z_P, dZ):
 
         # w_ad = velocity
         w_ad              = (velocity - w_firn_edges)
-        
+
         # w_ad[w_ad>0] = 0
 
         # w_ad[co_ind:+1] = 0
@@ -720,31 +742,31 @@ def w(airdict, z_edges, rho_edges, Z_P, dZ):
 def A(P):
     '''Power-law scheme, Patankar eq. 5.34'''
     A = np.maximum( (1 - 0.1 * np.abs( P ) )**5, np.zeros(np.size(P) ) )
-    return A    
+    return A
 
-def F_upwind(F): 
+def F_upwind(F):
     ''' Upwinding scheme '''
     F_upwind = np.maximum( F, 0 )
     return F_upwind
 
 
-# def w(z_edges,rho_edges,por_op,T,p_a,por_tot,por_cl,Z_P,dz, w_firn): # Function for downward advection of air and also calculates total air content. 
-    
+# def w(z_edges,rho_edges,por_op,T,p_a,por_tot,por_cl,Z_P,dz, w_firn): # Function for downward advection of air and also calculates total air content.
+
 #     por_tot_edges=np.interp(z_edges,Z_P,por_tot)
 #     por_cl_edges=np.interp(z_edges,Z_P,por_cl)
 #     por_op_edges=np.interp(z_edges,Z_P,por_op)
 #     teller_co=np.argmax(por_cl_edges)
 #     # w_firn_edges=Accu*rho_i/rho_edges #Check this - is there a better way?
 #     w_firn_edges=np.interp(z_edges,Z_P,w_firn)
-    
+
 #     # if ad_method=='ice_vel':
 #     #     w_ad=w_firn_edges
 #     #     trapped = 0.0
 #     #     bubble_pres = np.zeros_like(z_edges)
-    
+
 
 #     ### Christo's Method from his thesis (chapter 5). This (maybe) could be vectorized to speed it up.
-    
+
 #     bubble_pres = np.zeros_like(z_edges)
 #     # print(len(np.diff(por_cl)))
 #     # print(len(dz))
@@ -754,29 +776,29 @@ def F_upwind(F):
 #     C=np.exp(M_AIR*GRAVITY*z_edges/(R*T_edges))
 #     strain = np.gradient(np.log(w_firn),dz)
 #     s=por_op_edges+por_cl_edges
-    
-#     for teller1 in range (0,teller_co+1): 
+
+#     for teller1 in range (0,teller_co+1):
 #         integral = np.zeros(teller1+1)
 #         integral2 = np.zeros(teller1+1)
-        
+
 #         for teller2 in range(0,teller1+1):
 #             # integral[teller2] = dscl[teller2]*C[teller2]*(s[teller2]/s[teller1])/(1+scipy.integrate.trapz(strain[teller2:teller1+1],dz)) #need to get this indexing correct 6/19/14: I think it is fine.
 #             integral[teller2] = dscl[teller2]*C[teller2]*(s[teller2]/s[teller1])/(1+scipy.integrate.trapz(strain[teller2:teller1+1],z_edges[teller2:teller1+1])) #need to get this indexing correct 6/19/14: I think it is fine.
 #             if dscl[teller2]==0:
 #                 dscl[teller2]=1e-14
 #             integral2[teller2] = dscl[teller2]
-            
+
 #         bubble_pres[teller1] = (np.mean(dz)*np.sum(integral))/(np.mean(dz)*np.sum(integral2))
-    
+
 #     bubble_pres[teller_co+1:] = bubble_pres[teller_co]*(s[teller_co]/s[teller_co+1:])/(w_firn_edges[teller_co+1:]/w_firn_edges[teller_co])
-    
+
 #     bubble_pres[0] = 1
 #     #print 'bubble pressure = %s' % bubble_pres
-    
+
 #     flux= w_firn_edges[teller_co]*bubble_pres[teller_co]*por_cl[teller_co]
 
 #     velocity = np.minimum(w_firn_edges ,((flux+(1e-10)-w_firn_edges*bubble_pres*por_cl_edges)/((por_op_edges+1e-10)*C)))
-#     #velocity = velocity * 2   
+#     #velocity = velocity * 2
 #     w_ad=velocity
 
 


### PR DESCRIPTION
The linear-algebra library lapack contains an optimized solver for trilinear matrices.   I replaced the call to linsolv in solver.py with this function, and it 
1. seems to replicate the output of linsolv to within machine precision
2. takes about 10x less time (within solver.py)
Overhead from the rest of the code means that this change makes about an 0.5x change to total model runtime for the example.json run.

Solver.py now includes a flag to choose which function to use, and if both are enabled, the scaled difference between the two is reported to the command line.